### PR TITLE
Update extension to work with latest showdown version

### DIFF
--- a/showdown-xss-filter.js
+++ b/showdown-xss-filter.js
@@ -24,8 +24,8 @@
   };
 
   // Client-side export
-  if (typeof window !== 'undefined' && window.Showdown && window.Showdown.extensions) {
-    window.Showdown.extensions.xssfilter = xssfilter;
+  if (typeof window !== 'undefined' && window.showdown && window.showdown.extensions) {
+    window.showdown.extensions.xssfilter = xssfilter;
   }
 
   // Server-side export


### PR DESCRIPTION
From showdown v1.0.0 and onward, the namespace changed from `Showdown` to `showdown`. This change reflect the new namespace, making it compatible with the latest version
